### PR TITLE
Wiping blue's from pngs with no transparency.

### DIFF
--- a/png.js
+++ b/png.js
@@ -301,7 +301,7 @@
       var c, i, length, palette, pos, ret, transparency, _i, _ref, _ref1;
       palette = this.palette;
       transparency = this.transparency.indexed || [];
-      ret = new Uint8Array((transparency.length || 0) + palette.length);
+      ret = new Uint8Array((transparency.length || 255) + palette.length);
       pos = 0;
       length = palette.length;
       c = 0;

--- a/png.js
+++ b/png.js
@@ -301,7 +301,7 @@
       var c, i, length, palette, pos, ret, transparency, _i, _ref, _ref1;
       palette = this.palette;
       transparency = this.transparency.indexed || [];
-      ret = new Uint8Array((transparency.length || 255) + palette.length);
+      ret = new Uint8Array((transparency.length || 256) + palette.length);
       pos = 0;
       length = palette.length;
       c = 0;

--- a/png.js
+++ b/png.js
@@ -301,7 +301,7 @@
       var c, i, length, palette, pos, ret, transparency, _i, _ref, _ref1;
       palette = this.palette;
       transparency = this.transparency.indexed || [];
-      ret = new Uint8Array((transparency.length || 256) + palette.length);
+      ret = new Uint8Array((transparency.length || palette.length/3) + palette.length);
       pos = 0;
       length = palette.length;
       c = 0;


### PR DESCRIPTION
Probably better to not use transparency length to determine ret array size but incase it was used for something I left it in there.

It needs to be shifted when there is no transparency however, otherwise the blues get wiped from output png.
