### PR TITLE
include only png-node.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,5 +19,6 @@
       "prepublish": "coffee -c png-node.coffee"
   },
   "main": "png-node.js",
-  "engine": [ "node >= v0.6.0" ]
+  "engine": [ "node >= v0.6.0" ],
+  "files": [ "png-node.js" ]
 }


### PR DESCRIPTION
I believe the only file necessary to use this package is `png-node.js`. `images/` has fairly large image files in it, and I believe they are only necessary for development and testing.

I have tight size restrictions on a project of mine, so I'm trying to reduce any unecessary files in my dependencies. I think more people will benefit from this.
