### PR TITLE
Adding license info to the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "png-js",
   "description": "A PNG decoder in CoffeeScript",
   "version": "0.1.1",
+  "license": "MIT",
   "author": {
       "name": "Devon Govett",
       "email": "devongovett@gmail.com",


### PR DESCRIPTION
I'm working on the open source project [VersionEye](https://www.versioneye.com). By adding the license info to the package.json it becomes available through the public NPMRegistry API and that way other tools like VersionEye can fetch it easier.