### PR TITLE
Replace deprecated Buffer constructors with Buffer.from/Buffer.alloc

### DIFF
--- a/png-node.js
+++ b/png-node.js
@@ -140,7 +140,7 @@ module.exports = class PNG {
               break;
           }
 
-          this.imgData = new Buffer(this.imgData);
+          this.imgData = Buffer.from(this.imgData);
           return;
           break;
 
@@ -188,7 +188,7 @@ module.exports = class PNG {
       const { width, height } = this;
       const pixelBytes = this.pixelBitlength / 8;
 
-      const pixels = new Buffer(width * height * pixelBytes);
+      const pixels = Buffer.alloc(width * height * pixelBytes);
       const { length } = data;
       let pos = 0;
 
@@ -196,7 +196,7 @@ module.exports = class PNG {
         const w = Math.ceil((width - x0) / dx);
         const h = Math.ceil((height - y0) / dy);
         const scanlineLength = pixelBytes * w;
-        const buffer = singlePass ? pixels : new Buffer(scanlineLength * h);
+        const buffer = singlePass ? pixels : Buffer.alloc(scanlineLength * h);
         let row = 0;
         let c = 0;
         while (row < h && pos < length) {
@@ -337,7 +337,7 @@ module.exports = class PNG {
     const { palette } = this;
     const { length } = palette;
     const transparency = this.transparency.indexed || [];
-    const ret = new Buffer(transparency.length + length);
+    const ret = Buffer.alloc(transparency.length + length);
     let pos = 0;
     let c = 0;
 
@@ -393,7 +393,7 @@ module.exports = class PNG {
   }
 
   decode(fn) {
-    const ret = new Buffer(this.width * this.height * 4);
+    const ret = Buffer.alloc(this.width * this.height * 4);
     return this.decodePixels(pixels => {
       this.copyToImageData(ret, pixels);
       return fn(ret);


### PR DESCRIPTION
`new Buffer()` has been deprecated for a while now while still being used in the node.js version.

I've replaced the constructor call with their new replacements which is `Buffer.from()` and `Buffer.alloc()`.

Reference:
https://nodejs.org/docs/latest-v18.x/api/buffer.html