### PR TITLE
fix: use Buffer.concat instead of Array.push for IDAT chunks to prevent OOM

### DIFF
--- a/png-node.js
+++ b/png-node.js
@@ -43,6 +43,8 @@ module.exports = class PNG {
     this.imgData = [];
     this.transparency = {};
     this.text = {};
+    const _idatChunks = [];
+    let _idatTotalBytes = 0;
 
     while (true) {
       const chunkSize = this.readUInt32();
@@ -68,9 +70,9 @@ module.exports = class PNG {
           break;
 
         case 'IDAT':
-          for (i = 0; i < chunkSize; i++) {
-            this.imgData.push(this.data[this.pos++]);
-          }
+          _idatChunks.push(Buffer.from(this.data.slice(this.pos, this.pos + chunkSize)));
+          _idatTotalBytes += chunkSize;
+          this.pos += chunkSize;
           break;
 
         case 'tRNS':
@@ -140,7 +142,7 @@ module.exports = class PNG {
               break;
           }
 
-          this.imgData = new Buffer(this.imgData);
+          this.imgData = Buffer.concat(_idatChunks, _idatTotalBytes);
           return;
           break;
 


### PR DESCRIPTION
Closes #84

## Problem

The IDAT chunk parser accumulated compressed image data by pushing individual bytes into a JavaScript Array. For large PNG files (100MB+), this created arrays with 100M+ elements. Since V8 stores each Smi element using 8 bytes on 64-bit platforms, a 107MB PNG would consume ~860MB of heap memory, causing V8 to crash with `Fatal JavaScript invalid size error`.

## Solution

Replace the byte-by-byte `Array.push` approach with `Buffer.from/slice` to collect IDAT chunk data as Buffer slices, then `Buffer.concat` to merge them.

| | Before | After |
|---|--------|-------|
| 107MB IDAT | ~860MB heap (JS Array) | ~107MB heap (Buffer) |
| Result | V8 crash | Success |

---
This PR description was written by [Claude Code](https://claude.ai/claude-code) (claude-opus-4-6)