### PR TITLE
feat: replace Buffer with Uint8Array

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -131,7 +131,7 @@ class PNG {
               break;
           }
 
-          this.imgData = Buffer.from(this.imgData);
+          this.imgData = new Uint8Array(this.imgData);
           return;
           break;
 
@@ -179,7 +179,7 @@ class PNG {
       const { width, height } = this;
       const pixelBytes = this.pixelBitlength / 8;
 
-      const pixels = Buffer.alloc(width * height * pixelBytes);
+      const pixels = new Uint8Array(width * height * pixelBytes);
       const { length } = data;
       let pos = 0;
 
@@ -187,7 +187,7 @@ class PNG {
         const w = Math.ceil((width - x0) / dx);
         const h = Math.ceil((height - y0) / dy);
         const scanlineLength = pixelBytes * w;
-        const buffer = singlePass ? pixels : Buffer.alloc(scanlineLength * h);
+        const buffer = singlePass ? pixels : new Uint8Array(scanlineLength * h);
         let row = 0;
         let c = 0;
         while (row < h && pos < length) {
@@ -328,7 +328,7 @@ class PNG {
     const { palette } = this;
     const { length } = palette;
     const transparency = this.transparency.indexed || [];
-    const ret = Buffer.alloc(transparency.length + length);
+    const ret = new Uint8Array(transparency.length + length);
     let pos = 0;
     let c = 0;
 
@@ -384,7 +384,7 @@ class PNG {
   }
 
   decode(fn) {
-    const ret = Buffer.alloc(this.width * this.height * 4);
+    const ret = new Uint8Array(this.width * this.height * 4);
     return this.decodePixels(pixels => {
       this.copyToImageData(ret, pixels);
       return fn(ret);

--- a/test/imgdata.spec.js
+++ b/test/imgdata.spec.js
@@ -3,15 +3,16 @@ const PNGNode = require('../lib/png-js.cjs')
 
 const files = fs.readdirSync('test/images');
 
-function getImgData(Ctor, fileName) {
+function getImgData(Ctor, fileName, wrap) {
   const image = new Ctor(fs.readFileSync(`test/images/${fileName}`));
-  return image.imgData;
+  const imgData = image.imgData;
+  return wrap && !Buffer.isBuffer(imgData) ? Buffer.from(imgData) : imgData;
 }
 
 describe('imgData', () => {
   describe('node', () => {
     test.each(files)('%s', fileName => {
-      expect(getImgData(PNGNode, fileName)).toMatchSnapshot();
+      expect(getImgData(PNGNode, fileName, true)).toMatchSnapshot();
     });
   });
 

--- a/test/pixels.spec.js
+++ b/test/pixels.spec.js
@@ -7,7 +7,7 @@ async function getPixels(Ctor, fileName) {
   const image = new Ctor(fs.readFileSync(`test/images/${fileName}`));
   return new Promise(resolve => {
     Ctor === PNGNode
-      ? image.decodePixels(resolve)
+      ? image.decodePixels(pixels => resolve(Buffer.isBuffer(pixels) ? pixels : Buffer.from(pixels)))
       : resolve(image.decodePixels());
   });
 }


### PR DESCRIPTION
Remove Node.js Buffer dependency in favor of standard Uint8Array, making it truly isomorphic without needing any polyfill. Technically a breaking change so I'll publish a 2.0.0, although it should not break most usages as UInt8Array are supported on any Node.js api that supports Buffer. I tested pdfkit with this and no changes are needed on that side