### PR TITLE
fix: declare MIT license in package metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "png-js",
   "description": "A PNG decoder in JavaScript",
   "version": "2.0.0",
+  "license": "MIT",
   "type": "module",
   "main": "./lib/png-js.cjs",
   "module": "./lib/png-js.js",


### PR DESCRIPTION
## Summary

- declare the package license as MIT in package.json
- align npm metadata with the existing MIT LICENSE file
- allow automated license and SBOM tooling to identify the package license

Fixes #79

## Verification

- yarn test (3 suites, 114 tests)
- npm pack --dry-run --json
- npm pkg get license returns MIT